### PR TITLE
[WIP] - Examples in iOS demo app working properly

### DIFF
--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -91,10 +91,14 @@ public class OAuth2Swift: NSObject {
             urlString += "&\(param.0)=\(param.1)"
         }
 
-        if let queryURL = NSURL(string: urlString) {
-           //self.authorize_url_handler.handle(queryURL)
-           self.authorize_url_block(queryURL)
+        if let queryString = urlString.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet()) {
+            print(queryString)
+            if let queryURL = NSURL(string: queryString) {
+                print("queryURL is valid")
+                self.authorize_url_handler.handle(queryURL)
+            }
         }
+
     }
     
     func postOAuthAccessTokenWithRequestTokenByCode(code: String, callbackURL: NSURL, success: TokenSuccessHandler, failure: FailureHandler?) {

--- a/OAuthSwiftDemo/ViewController.swift
+++ b/OAuthSwiftDemo/ViewController.swift
@@ -463,7 +463,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
 
     func snapshot() -> NSData {
         UIGraphicsBeginImageContext(self.view.frame.size)
-        self.view.layer.renderInContext(UIGraphicsGetCurrentContext())
+        self.view.layer.renderInContext(UIGraphicsGetCurrentContext()!)
         let fullScreenshot = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         UIImageWriteToSavedPhotosAlbum(fullScreenshot, nil, nil, nil)

--- a/OAuthSwiftDemo/WebViewController.swift
+++ b/OAuthSwiftDemo/WebViewController.swift
@@ -15,7 +15,7 @@ class WebViewController: OAuthWebViewController, UIWebViewDelegate {
     let webView : UIWebView = UIWebView()
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.webView.frame = UIScreen.mainScreen().applicationFrame
+        self.webView.frame = UIScreen.mainScreen().bounds
         self.webView.scalesPageToFit = true
         self.webView.delegate = self
         self.view.addSubview(self.webView)


### PR DESCRIPTION
This pull request fixes an issue that was preventing the GitHub example (and others) from presenting the `SFSafariViewController` and silences two of the _deprecated in iOS 9_ warnings.
